### PR TITLE
Publish docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ jobs:
             - dependency-cache-
       - run: npm install
       - run: npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
+      # - run: echo "VERSION=1.0.1" > RELEASE.env # debug
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - RELEASE.env
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
@@ -51,6 +56,18 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Check if new release
+          command: |
+            if [ ! -f RELEASE.env ]; then
+              echo "No new release detected, skipping Docker Hub publish..."
+              exit 0
+            else
+              source RELEASE.env
+              cat RELEASE.env
+            fi
       - run:
           name: Build Docker image
           command: make build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
             - dependency-cache-
       - run: npm install
       - run: |
+          echo -e "NEW_RELEASE=false" > RELEASE.env # will be overriden if release detected
           npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
           cat RELEASE.env
       # - run: echo -e "NEW_RELEASE=true\nVERSION=1.0.1" > RELEASE.env # force publish docker images at hard-coded version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: |
           npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
           cat RELEASE.env
-      - run: echo -e "NEW_RELEASE=true\nVERSION=1.0.1" > RELEASE.env
+      # - run: echo -e "NEW_RELEASE=true\nVERSION=1.0.1" > RELEASE.env # force publish docker images at hard-coded version
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -76,12 +76,12 @@ jobs:
               docker tag ${IMAGE_NAME}:markdown ${IMAGE_NAME}:markdown-${VERSION}
               echo "Publishing images..."
               echo "${DOCKERHUB_PASS}" | docker login -u "$DOCKERHUB_USER" --password-stdin
-              docker push ${IMAGE_NAME}:latest
+              docker push ${IMAGE_NAME}:dev-${VERSION}
               docker push ${IMAGE_NAME}:dev
+              docker push ${IMAGE_NAME}:markdown-${VERSION}
               docker push ${IMAGE_NAME}:markdown
               docker push ${IMAGE_NAME}:${VERSION}
-              docker push ${IMAGE_NAME}:dev-${VERSION}
-              docker push ${IMAGE_NAME}:markdown-${VERSION}
+              docker push ${IMAGE_NAME}:latest
             else
               echo "No new release detected, skipping Docker Hub publish..."
               exit 0
@@ -110,9 +110,8 @@ workflows:
                 - master
       - publish-docker:
           requires:
-            - release-dry-run
+            - release
           filters:
             branches:
               only:
                 - master
-                - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ jobs:
               docker push ${IMAGE_NAME}:latest
             else
               echo "No new release detected, skipping Docker Hub publish..."
-              exit 0
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - run: |
           npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
           cat RELEASE.env
+      - run: echo -e "NEW_RELEASE=true\nVERSION=1.0.1" > RELEASE.env
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           paths:
             - node_modules
 
-  build-image:
+  build-images:
     docker:
       - image: circleci/buildpack-deps:stretch
     environment:
@@ -60,6 +60,13 @@ jobs:
       - run:
           name: Build Markdown Docker image
           command: make build-markdown
+      - run:
+          name: Publish Images
+          command: |
+            echo "${DOCKERHUB_PASS}" | docker login -u "$DOCKERHUB_USER" --password-stdin
+            docker push ${IMAGE_NAME}:latest
+            docker push ${IMAGE_NAME}:dev
+            docker push ${IMAGE_NAME}:markdown
 
 workflows:
   version: 2
@@ -82,7 +89,7 @@ workflows:
             branches:
               only:
                 - master
-      - build-image:
+      - build-images:
           requires:
             - release-dry-run
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,24 @@ jobs:
           paths:
             - node_modules
 
+  build-image:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    environment:
+      IMAGE_NAME: hackerhappyhour/reveal
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image
+          command: make build
+      - run:
+          name: Build Dev Docker image
+          command: make build-dev
+      - run:
+          name: Build Markdown Docker image
+          command: make build-markdown
+
 workflows:
   version: 2
   build-and-release:
@@ -64,3 +82,11 @@ workflows:
             branches:
               only:
                 - master
+      - build-image:
+          requires:
+            - release-dry-run
+          filters:
+            branches:
+              only:
+                - master
+                - publish-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
             - dependency-cache-
       - run: npm install
       - run: npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
-      # - run: echo "VERSION=1.0.1" > RELEASE.env # debug
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -48,7 +47,7 @@ jobs:
           paths:
             - node_modules
 
-  build-images:
+  publish-docker:
     docker:
       - image: circleci/buildpack-deps:stretch
     environment:
@@ -59,31 +58,23 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: Check if new release
+          name: Build and publish
           command: |
-            if [ ! -f RELEASE.env ]; then
+            cat RELEASE.env
+            source RELEASE.env
+            if [ "$NEW_RELEASE" = true ]; then
+              echo "Building images..."
+              make build
+              make build-dev
+              make build-markdown
+              echo "${DOCKERHUB_PASS}" | docker login -u "$DOCKERHUB_USER" --password-stdin
+              docker push ${IMAGE_NAME}:latest
+              docker push ${IMAGE_NAME}:dev
+              docker push ${IMAGE_NAME}:markdown
+            else
               echo "No new release detected, skipping Docker Hub publish..."
               exit 0
-            else
-              source RELEASE.env
-              cat RELEASE.env
             fi
-      - run:
-          name: Build Docker image
-          command: make build
-      - run:
-          name: Build Dev Docker image
-          command: make build-dev
-      - run:
-          name: Build Markdown Docker image
-          command: make build-markdown
-      - run:
-          name: Publish Images
-          command: |
-            echo "${DOCKERHUB_PASS}" | docker login -u "$DOCKERHUB_USER" --password-stdin
-            docker push ${IMAGE_NAME}:latest
-            docker push ${IMAGE_NAME}:dev
-            docker push ${IMAGE_NAME}:markdown
 
 workflows:
   version: 2
@@ -106,7 +97,7 @@ workflows:
             branches:
               only:
                 - master
-      - build-images:
+      - publish-docker:
           requires:
             - release-dry-run
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
             - dependency-cache-{{ checksum "package.json" }}
             - dependency-cache-
       - run: npm install
-      - run: npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
+      - run: |
+          npx semantic-release --branch $CIRCLE_BRANCH --dry-run=<< parameters.dry-run >>
+          cat RELEASE.env
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -61,16 +63,24 @@ jobs:
           name: Build and publish
           command: |
             cat RELEASE.env
-            source RELEASE.env
+            source RELEASE.env # loads VERSION and NEW_RELEASE env vars in to environment
             if [ "$NEW_RELEASE" = true ]; then
               echo "Building images..."
               make build
               make build-dev
               make build-markdown
+              echo "Tagging images with version: ${VERSION}..."
+              docker tag ${IMAGE_NAME}:latest ${IMAGE_NAME}:${VERSION}
+              docker tag ${IMAGE_NAME}:dev ${IMAGE_NAME}:dev-${VERSION}
+              docker tag ${IMAGE_NAME}:markdown ${IMAGE_NAME}:markdown-${VERSION}
+              echo "Publishing images..."
               echo "${DOCKERHUB_PASS}" | docker login -u "$DOCKERHUB_USER" --password-stdin
               docker push ${IMAGE_NAME}:latest
               docker push ${IMAGE_NAME}:dev
               docker push ${IMAGE_NAME}:markdown
+              docker push ${IMAGE_NAME}:${VERSION}
+              docker push ${IMAGE_NAME}:dev-${VERSION}
+              docker push ${IMAGE_NAME}:markdown-${VERSION}
             else
               echo "No new release detected, skipping Docker Hub publish..."
               exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-.PHONY: build markdown
+IMAGE_NAME=hackerhappyhour/reveal
+
+.PHONY: build build-dev build-markdown
 
 build:
-	docker build -f docker/Dockerfile -t hackerhappyhour/reveal:latest ./docker
+	docker build -f docker/Dockerfile -t ${IMAGE_NAME}:latest ./docker
 
-markdown:
-	docker build -f docker/markdown/Dockerfile -t hackerhappyhour/reveal:markdown ./docker
+build-dev:
+	docker build -f docker/dev/Dockerfile -t ${IMAGE_NAME}:dev ./docker
+
+build-markdown:
+	docker build -f docker/markdown/Dockerfile -t ${IMAGE_NAME}:markdown ./docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,11 @@ FROM node:10 AS builder
 
 WORKDIR /reveal
 
-RUN npm install reveal.js
+RUN npm install @h3/reveal
 
 FROM nginx:1.15
+
+LABEL source="https://github.com/HackerHappyHour/reveal"
 
 ENV SITE=/usr/share/nginx/html
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:10 AS builder
+
+LABEL source="https://github.com/HackerHappyHour/reveal"
+
+RUN cd /tmp \
+  && npm install @h3/reveal \
+  && mv node_modules/@h3/reveal / \
+  && cd /reveal \
+  && npm install \
+  && npm cache clean --force
+
+WORKDIR /reveal
+
+EXPOSE 8000 35729
+
+CMD ["npm", "start"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10 AS builder
+FROM node:10
 
 LABEL source="https://github.com/HackerHappyHour/reveal"
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,12 @@
+# Example docker-compose.yml file implementation
+version: '3'
+services:
+  reveal:
+    image: hackerhappyhour/reveal:dev
+    ports:
+      - "8000:8000"
+      - "35729:35729" # live-reload server
+    volumes:
+      - ./index.html:/reveal/index.html
+      # - ./css/main.css:/reveal/css/main.css
+      # - ./images:/reveal/images

--- a/docker/dev/index.html
+++ b/docker/dev/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+		<title>reveal.js</title>
+
+		<link rel="stylesheet" href="css/reveal.css">
+		<link rel="stylesheet" href="css/theme/black.css">
+
+		<!-- Theme used for syntax highlighting of code -->
+		<link rel="stylesheet" href="lib/css/zenburn.css">
+
+		<!-- Printing and PDF exports -->
+		<script>
+			var link = document.createElement( 'link' );
+			link.rel = 'stylesheet';
+			link.type = 'text/css';
+			link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+			document.getElementsByTagName( 'head' )[0].appendChild( link );
+		</script>
+	</head>
+	<body>
+		<div class="reveal">
+			<div class="slides">
+				<section>Slide 1</section>
+				<section>Slide 2</section>
+			</div>
+		</div>
+
+		<script src="lib/js/head.min.js"></script>
+		<script src="js/reveal.js"></script>
+
+		<script>
+			// More info about config & dependencies:
+			// - https://github.com/hakimel/reveal.js#configuration
+			// - https://github.com/hakimel/reveal.js#dependencies
+			Reveal.initialize({
+				dependencies: [
+					{ src: 'plugin/markdown/marked.js' },
+					{ src: 'plugin/markdown/markdown.js' },
+					{ src: 'plugin/notes/notes.js', async: true },
+					{ src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
+				]
+			});
+		</script>
+	</body>
+</html>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
-  revealjs:
-    image: reveal.js
+  reveal:
+    image: reveal
     build: .
     ports:
       - "8080:8080"

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -23,6 +23,7 @@ module.exports = grunt => {
 				args: [
 					'--no-snadbox',
 					'--disable-setuid-sandbox',
+					'--disable-dev-shm-usage'
 				]
 			}
 		};

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,8 @@ module.exports = {
     '@semantic-release/git',
     '@semantic-release/github',
     ['@semantic-release/exec', {
-      verifyReleaseCmd: 'echo "VERSION=${nextRelease.version}" > RELEASE.env'
+      verifyConditionsCmd: 'echo "NEW_RELEASE=false" > RELEASE.env',
+      verifyReleaseCmd: 'echo "VERSION=${nextRelease.version}\nNEW_RELEASE=true" > RELEASE.env'
     }],
   ],
   debug: true,

--- a/release.config.js
+++ b/release.config.js
@@ -9,7 +9,6 @@ module.exports = {
     '@semantic-release/git',
     '@semantic-release/github',
     ['@semantic-release/exec', {
-      verifyConditionsCmd: 'echo "NEW_RELEASE=false" > RELEASE.env',
       verifyReleaseCmd: 'echo "VERSION=${nextRelease.version}\nNEW_RELEASE=true" > RELEASE.env'
     }],
   ],


### PR DESCRIPTION
The PR enables Docker image building and publishing to Docker Hub [hackerhappyhour/reveal](https://cloud.docker.com/u/hackerhappyhour/repository/docker/hackerhappyhour/reveal) repo.

It will only publish Docker images if a new release is detected from the semantic-release tool in a prior job in the pipeline. 

Closes #22 